### PR TITLE
Add initial architecture data structure

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,35 @@ import MenuIcon from '@mui/icons-material/Menu';
 import { Layout, Model } from 'flexlayout-react';
 import 'flexlayout-react/style/dark.css';
 
+const data = {
+  architecture: {
+    CGRAs: [
+      {
+        id: 'cgra-1',
+        x: 0,
+        y: 0,
+        PEs: [
+          { id: 'pe-1-1', x: 0, y: 0 },
+          { id: 'pe-1-2', x: 1, y: 0 },
+          { id: 'pe-1-3', x: 0, y: 1 },
+          { id: 'pe-1-4', x: 1, y: 1 }
+        ]
+      },
+      {
+        id: 'cgra-2',
+        x: 2,
+        y: 0,
+        PEs: [
+          { id: 'pe-2-1', x: 0, y: 0 },
+          { id: 'pe-2-2', x: 1, y: 0 },
+          { id: 'pe-2-3', x: 0, y: 1 },
+          { id: 'pe-2-4', x: 1, y: 1 }
+        ]
+      }
+    ]
+  }
+};
+
 const initialLayout = {
   global: {
     tabSetMinHeight: 200,


### PR DESCRIPTION
## Summary
- define the initial architecture data object for CGRAs and PEs that will drive the UI later

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e440c2d4d4832583fe1795a0e61b13