### PR TITLE
Add configurable property inspector for CGRA elements

### DIFF
--- a/src/PropertyInspector.jsx
+++ b/src/PropertyInspector.jsx
@@ -1,0 +1,214 @@
+import { Fragment, useMemo } from 'react';
+import {
+  Box,
+  Divider,
+  MenuItem,
+  Switch,
+  TextField,
+  Typography
+} from '@mui/material';
+import { PROPERTY_SCHEMAS, PROPERTY_TITLES } from './propertySchemas';
+
+function PropertyInspector({ architecture, selection, onPropertyChange }) {
+  const { entity, schema } = useMemo(() => {
+    if (!selection) {
+      return { entity: null, schema: null };
+    }
+
+    if (selection.type === 'cgra') {
+      const found = architecture.CGRAs.find((cgra) => cgra.id === selection.id);
+      return { entity: found ?? null, schema: PROPERTY_SCHEMAS.cgra };
+    }
+
+    if (selection.type === 'router') {
+      const parent = architecture.CGRAs.find((cgra) => cgra.id === selection.cgraId);
+      return { entity: parent?.router ?? null, schema: PROPERTY_SCHEMAS.router };
+    }
+
+    if (selection.type === 'pe') {
+      const parent = architecture.CGRAs.find((cgra) => cgra.id === selection.cgraId);
+      const found = parent?.PEs.find((pe) => pe.id === selection.id);
+      return { entity: found ?? null, schema: PROPERTY_SCHEMAS.pe };
+    }
+
+    return { entity: null, schema: null };
+  }, [architecture, selection]);
+
+  const title = selection ? PROPERTY_TITLES[selection.type] ?? 'Inspector' : 'Inspector';
+
+  const handleTextOrNumberChange = (property) => (event) => {
+    const { value } = event.target;
+    if (!selection || !property.mutable) return;
+
+    if (property.type === 'number') {
+      if (value === '') {
+        onPropertyChange(selection, property.key, null);
+        return;
+      }
+
+      const numericValue = Number(value);
+      if (Number.isNaN(numericValue)) return;
+
+      let clampedValue = numericValue;
+      if (typeof property.min === 'number') {
+        clampedValue = Math.max(property.min, clampedValue);
+      }
+      if (typeof property.max === 'number') {
+        clampedValue = Math.min(property.max, clampedValue);
+      }
+
+      onPropertyChange(selection, property.key, clampedValue);
+      return;
+    }
+
+    onPropertyChange(selection, property.key, value);
+  };
+
+  const handleBooleanChange = (property) => (event) => {
+    if (!selection || !property.mutable) return;
+    onPropertyChange(selection, property.key, event.target.checked);
+  };
+
+  if (!selection) {
+    return (
+      <Box
+        sx={{
+          height: '100%',
+          p: 2.5,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 2,
+          borderRadius: 1,
+          bgcolor: 'rgba(148,163,184,0.08)',
+          color: 'text.secondary'
+        }}
+      >
+        <Typography variant="subtitle1" color="text.primary">
+          Inspector
+        </Typography>
+        <Typography variant="body2">
+          Select a CGRA, router, or processing element to edit its properties.
+        </Typography>
+      </Box>
+    );
+  }
+
+  if (!entity || !schema) {
+    return (
+      <Box
+        sx={{
+          height: '100%',
+          p: 2.5,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 2,
+          borderRadius: 1,
+          bgcolor: 'rgba(148,163,184,0.08)',
+          color: 'text.secondary'
+        }}
+      >
+        <Typography variant="subtitle1" color="text.primary">
+          {title}
+        </Typography>
+        <Typography variant="body2">
+          The selected entity is no longer available in the current architecture.
+        </Typography>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      sx={{
+        height: '100%',
+        p: 2.5,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 2,
+        borderRadius: 1,
+        bgcolor: 'rgba(148,163,184,0.08)',
+        color: 'text.secondary',
+        overflow: 'auto'
+      }}
+    >
+      <Typography variant="subtitle1" color="text.primary">
+        {title}
+      </Typography>
+      <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+        Adjust configuration values to explore different CGRA layouts and capabilities.
+      </Typography>
+      <Divider flexItem sx={{ borderColor: 'rgba(148,163,184,0.3)' }} />
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: 'minmax(120px, 0.65fr) 1fr',
+          rowGap: 1.25,
+          columnGap: 2,
+          alignItems: 'center'
+        }}
+      >
+        {schema.map((property) => {
+          const value = entity[property.key];
+          const commonProps = {
+            fullWidth: true,
+            size: 'small',
+            disabled: property.mutable === false
+          };
+
+          let input = null;
+
+          if (property.type === 'select') {
+            input = (
+              <TextField
+                {...commonProps}
+                select
+                value={value ?? ''}
+                onChange={handleTextOrNumberChange(property)}
+              >
+                {property.options.map((option) => (
+                  <MenuItem key={option} value={option}>
+                    {option}
+                  </MenuItem>
+                ))}
+              </TextField>
+            );
+          } else if (property.type === 'boolean') {
+            input = (
+              <Switch
+                checked={Boolean(value)}
+                onChange={handleBooleanChange(property)}
+                color="primary"
+                disabled={property.mutable === false}
+              />
+            );
+          } else {
+            input = (
+              <TextField
+                {...commonProps}
+                type={property.type === 'number' ? 'number' : 'text'}
+                value={value ?? ''}
+                onChange={handleTextOrNumberChange(property)}
+                inputProps={{
+                  min: property.min,
+                  max: property.max,
+                  step: property.step
+                }}
+              />
+            );
+          }
+
+          return (
+            <Fragment key={property.key}>
+              <Typography variant="body2" sx={{ color: 'text.secondary' }}>
+                {property.label}
+              </Typography>
+              <Box>{input}</Box>
+            </Fragment>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+}
+
+export default PropertyInspector;

--- a/src/propertySchemas.js
+++ b/src/propertySchemas.js
@@ -1,0 +1,90 @@
+export const PROPERTY_SCHEMAS = {
+  cgra: [
+    { key: 'id', label: 'Identifier', type: 'text', mutable: false },
+    { key: 'label', label: 'Display Label', type: 'text', mutable: true },
+    { key: 'x', label: 'X Position', type: 'number', mutable: false },
+    { key: 'y', label: 'Y Position', type: 'number', mutable: false },
+    {
+      key: 'clockFrequency',
+      label: 'Clock (MHz)',
+      type: 'number',
+      mutable: true,
+      min: 100,
+      max: 2000,
+      step: 10
+    },
+    {
+      key: 'voltage',
+      label: 'Voltage (V)',
+      type: 'number',
+      mutable: true,
+      min: 0.5,
+      max: 1.5,
+      step: 0.05
+    }
+  ],
+  router: [
+    { key: 'id', label: 'Identifier', type: 'text', mutable: false },
+    { key: 'cgraId', label: 'CGRA', type: 'text', mutable: false },
+    {
+      key: 'routingStrategy',
+      label: 'Routing Strategy',
+      type: 'select',
+      mutable: true,
+      options: ['Shortest Path', 'Load Balanced', 'Fault Tolerant']
+    },
+    {
+      key: 'bufferDepth',
+      label: 'Buffer Depth',
+      type: 'number',
+      mutable: true,
+      min: 1,
+      max: 64,
+      step: 1
+    },
+    {
+      key: 'bandwidth',
+      label: 'Bandwidth (GB/s)',
+      type: 'number',
+      mutable: true,
+      min: 1,
+      max: 512,
+      step: 1
+    }
+  ],
+  pe: [
+    { key: 'id', label: 'Identifier', type: 'text', mutable: false },
+    { key: 'cgraId', label: 'CGRA', type: 'text', mutable: false },
+    { key: 'label', label: 'Display Label', type: 'text', mutable: true },
+    { key: 'x', label: 'X Coordinate', type: 'number', mutable: false },
+    { key: 'y', label: 'Y Coordinate', type: 'number', mutable: false },
+    {
+      key: 'operation',
+      label: 'Operation',
+      type: 'select',
+      mutable: true,
+      options: ['ALU', 'MAC', 'Load/Store', 'Branch']
+    },
+    {
+      key: 'latency',
+      label: 'Latency (cycles)',
+      type: 'number',
+      mutable: true,
+      min: 1,
+      max: 16,
+      step: 1
+    },
+    {
+      key: 'enabled',
+      label: 'Enabled',
+      type: 'boolean',
+      mutable: true
+    }
+  ]
+};
+
+export const PROPERTY_TITLES = {
+  cgra: 'CGRA Properties',
+  router: 'Router Properties',
+  pe: 'Processing Element Properties'
+};


### PR DESCRIPTION
## Summary
- lift CGRA architecture state into the app and expose selection to the layout
- add a configurable property inspector with schemas for CGRAs, routers, and PEs
- tighten canvas highlighting so only the active entity is emphasized while labels stay in sync

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5c8eb5cd08325b2a431e1ea2bd552