### PR TITLE
Add save and load controls for application state

### DIFF
--- a/src/app_data.js
+++ b/src/app_data.js
@@ -1,24 +1,24 @@
-const MULTI_CGRA_ROWS = 4;
-const MULTI_CGRA_COLUMNS = 4;
-const PE_ROWS = 4;
-const PE_COLUMNS = 4;
+const appData = (() => {
+  const MULTI_CGRA_ROWS = 4;
+  const MULTI_CGRA_COLUMNS = 4;
+  const PE_ROWS = 4;
+  const PE_COLUMNS = 4;
 
-const functionalUnitDefaults = {
-  phi: true,
-  shift: true,
-  select: false,
-  mac: true,
-  return: false,
-  logic: true,
-  load: true,
-  store: true,
-  compare: false,
-  add: true,
-  mul: true
-};
+  const functionalUnitDefaults = {
+    phi: true,
+    shift: true,
+    select: false,
+    mac: true,
+    return: false,
+    logic: true,
+    load: true,
+    store: true,
+    compare: false,
+    add: true,
+    mul: true
+  };
 
-function buildOutgoingLinks(x, y, maxX, maxY) {
-  return {
+  const buildOutgoingLinks = (x, y, maxX, maxY) => ({
     nw: x > 0 && y > 0,
     sw: x > 0 && y < maxY,
     ne: x < maxX && y > 0,
@@ -27,65 +27,71 @@ function buildOutgoingLinks(x, y, maxX, maxY) {
     s: y < maxY,
     w: x > 0,
     e: x < maxX
+  });
+
+  const buildProcessingElements = (offsetY, offsetX) => {
+    const pes = [];
+    for (let row = 0; row < PE_ROWS; row += 1) {
+      for (let col = 0; col < PE_COLUMNS; col += 1) {
+        pes.push({
+          id: `pe-${offsetY}-${offsetX}-${row}-${col}`,
+          label: `PE (${row}, ${col})`,
+          x: col,
+          y: row,
+          disabled: false,
+          tileFunctionalUnits: { ...functionalUnitDefaults },
+          outgoingLinks: buildOutgoingLinks(
+            col,
+            row,
+            PE_COLUMNS - 1,
+            PE_ROWS - 1
+          )
+        });
+      }
+    }
+    return pes;
   };
-}
 
-function buildProcessingElements(offsetY, offsetX) {
-  const pes = [];
-  for (let row = 0; row < PE_ROWS; row += 1) {
-    for (let col = 0; col < PE_COLUMNS; col += 1) {
-      pes.push({
-        id: `pe-${offsetY}-${offsetX}-${row}-${col}`,
-        label: `PE (${row}, ${col})`,
-        x: col,
-        y: row,
-        disabled: false,
-        tileFunctionalUnits: { ...functionalUnitDefaults },
-        outgoingLinks: buildOutgoingLinks(
-          col,
-          row,
-          PE_COLUMNS - 1,
-          PE_ROWS - 1
-        )
-      });
+  const buildCgras = () => {
+    const arrays = [];
+    for (let row = 0; row < MULTI_CGRA_ROWS; row += 1) {
+      for (let col = 0; col < MULTI_CGRA_COLUMNS; col += 1) {
+        arrays.push({
+          id: `cgra-${row}-${col}`,
+          label: `CGRA (${row}, ${col})`,
+          x: col,
+          y: row,
+          intraTopology: 'KingMesh',
+          sramBanks: 16,
+          perCgraRows: PE_ROWS,
+          perCgraColumns: PE_COLUMNS,
+          configMemoryEntries: 8,
+          router: {
+            id: `router-${row}-${col}`
+          },
+          PEs: buildProcessingElements(row, col)
+        });
+      }
     }
-  }
-  return pes;
-}
+    return arrays;
+  };
 
-function buildCgras() {
-  const arrays = [];
-  for (let row = 0; row < MULTI_CGRA_ROWS; row += 1) {
-    for (let col = 0; col < MULTI_CGRA_COLUMNS; col += 1) {
-      arrays.push({
-        id: `cgra-${row}-${col}`,
-        label: `CGRA (${row}, ${col})`,
-        x: col,
-        y: row,
-        intraTopology: 'KingMesh',
-        sramBanks: 16,
-        perCgraRows: PE_ROWS,
-        perCgraColumns: PE_COLUMNS,
-        configMemoryEntries: 8,
-        router: {
-          id: `router-${row}-${col}`
-        },
-        PEs: buildProcessingElements(row, col)
-      });
+  return {
+    version: 1,
+    architecture: {
+      id: 'device-reference',
+      name: 'Reference CGRA Device',
+      totalSramKb: 1024,
+      interTopology: 'KingMesh',
+      multiCgraRows: MULTI_CGRA_ROWS,
+      multiCgraColumns: MULTI_CGRA_COLUMNS,
+      vectorLanes: 1,
+      dataBitwidth: 32,
+      CGRAs: buildCgras()
     }
-  }
-  return arrays;
-}
+  };
+})();
 
-export const defaultArchitecture = {
-  id: 'device-reference',
-  name: 'Reference CGRA Device',
-  totalSramKb: 1024,
-  interTopology: 'KingMesh',
-  multiCgraRows: MULTI_CGRA_ROWS,
-  multiCgraColumns: MULTI_CGRA_COLUMNS,
-  vectorLanes: 1,
-  dataBitwidth: 32,
-  CGRAs: buildCgras()
-};
+export const defaultAppData = appData;
+
 


### PR DESCRIPTION
## Summary
- reorganize the default application data into a serializable object
- add save and load actions to the navigation menu for exporting/importing JSON files
- update state management to operate on the shared app data container

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e7ee690f7c8325baabe99798fa45c5