### PR TITLE
Add runner heartbeat lease recovery and watchdog

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -56,6 +56,18 @@ Deploys the job runner to production server.
   - Uses PM2 for process management
   - Preserves PR-specific runners
 
+### 🩺 [runner-watchdog.yml](./runner-watchdog.yml)
+**Production Runner Watchdog**
+
+Periodically verifies the production runner is online and attempts restart if down.
+
+- **Triggers:** Scheduled every 10 minutes, manual dispatch
+- **Runs on:** Ubuntu latest
+- **Key steps:**
+  - SSH health check of PM2 process `cgra-runner`
+  - Automatic restart if process is offline
+  - Fails workflow if restart cannot recover the process
+
 ## Status Badges
 
 Add these to your README.md:
@@ -65,6 +77,7 @@ Add these to your README.md:
 ![Converter Tests](https://github.com/syifan/cgra-flow-ui/actions/workflows/converter-tests.yml/badge.svg)
 ![Preview Environment](https://github.com/syifan/cgra-flow-ui/actions/workflows/preview-environment.yml/badge.svg)
 ![Production Runner](https://github.com/syifan/cgra-flow-ui/actions/workflows/production-runner.yml/badge.svg)
+![Runner Watchdog](https://github.com/syifan/cgra-flow-ui/actions/workflows/runner-watchdog.yml/badge.svg)
 ```
 
 ## Required Secrets
@@ -86,6 +99,12 @@ Configure these in repository settings → Secrets and variables → Actions:
 - `RUNNER_SSH_KEY` - SSH private key
 - `SUPABASE_URL` - Supabase project URL
 - `SUPABASE_SERVICE_ROLE_KEY` - Supabase service role key
+
+### For runner-watchdog.yml
+- `RUNNER_SSH_HOST` - Production server hostname
+- `RUNNER_SSH_PORT` - SSH port (default: 22)
+- `RUNNER_SSH_USER` - SSH username
+- `RUNNER_SSH_KEY` - SSH private key
 
 ## Local Testing
 

--- a/.github/workflows/runner-watchdog.yml
+++ b/.github/workflows/runner-watchdog.yml
@@ -1,0 +1,70 @@
+name: Runner Watchdog
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: production-runner-watchdog
+  cancel-in-progress: false
+
+jobs:
+  ensure-runner-online:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check and restart production runner if needed
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.RUNNER_SSH_HOST }}
+          port: ${{ secrets.RUNNER_SSH_PORT || 22 }}
+          username: ${{ secrets.RUNNER_SSH_USER }}
+          key: ${{ secrets.RUNNER_SSH_KEY }}
+          command_timeout: 5m
+          script: |
+            set -euo pipefail
+
+            PROCESS_NAME="cgra-runner"
+            RUNNER_DIR="$HOME/cgra-runner/repo/runner"
+
+            if ! command -v pm2 >/dev/null 2>&1; then
+              echo "pm2 is not installed on host"
+              exit 1
+            fi
+
+            pid="$(pm2 pid "$PROCESS_NAME" | tail -n 1 | tr -d '[:space:]')"
+            if [ -n "${pid:-}" ] && [ "$pid" != "0" ]; then
+              echo "$PROCESS_NAME is healthy (pid=$pid)"
+              pm2 status "$PROCESS_NAME"
+              exit 0
+            fi
+
+            echo "$PROCESS_NAME is offline. Attempting restart..."
+            if [ ! -d "$RUNNER_DIR" ]; then
+              echo "Runner directory missing: $RUNNER_DIR"
+              exit 1
+            fi
+
+            cd "$RUNNER_DIR"
+
+            if [ -f ecosystem.config.cjs ]; then
+              pm2 startOrReload ecosystem.config.cjs --update-env
+            elif [ -f start.sh ]; then
+              pm2 start ./start.sh --name "$PROCESS_NAME"
+            else
+              echo "No restart entrypoint found (expected ecosystem.config.cjs or start.sh)"
+              exit 1
+            fi
+
+            pm2 save
+            sleep 3
+
+            new_pid="$(pm2 pid "$PROCESS_NAME" | tail -n 1 | tr -d '[:space:]')"
+            if [ -z "${new_pid:-}" ] || [ "$new_pid" = "0" ]; then
+              echo "Runner restart failed"
+              pm2 logs "$PROCESS_NAME" --lines 50 --nostream || true
+              exit 1
+            fi
+
+            echo "$PROCESS_NAME restarted successfully (pid=$new_pid)"

--- a/runner/.env.example
+++ b/runner/.env.example
@@ -5,6 +5,8 @@ SUPABASE_SERVICE_ROLE_KEY=...
 # Runner configuration
 RUNNER_ID=runner-001
 POLL_INTERVAL_MS=5000
+HEARTBEAT_INTERVAL_MS=10000
+JOB_LEASE_TIMEOUT_SECONDS=300
 
 # Runner mode: 'fake' for testing, 'real' for actual Docker execution
 RUNNER_MODE=fake

--- a/runner/README.md
+++ b/runner/README.md
@@ -45,6 +45,8 @@ SUPABASE_SERVICE_ROLE_KEY=your_service_role_key
 RUNNER_MODE=fake  # or 'real' for actual Docker execution
 RUNNER_ID=runner-local
 POLL_INTERVAL_MS=5000
+HEARTBEAT_INTERVAL_MS=10000
+JOB_LEASE_TIMEOUT_SECONDS=300
 
 # Real mode settings (required for RUNNER_MODE=real)
 JOBS_DIR=./jobs
@@ -272,6 +274,9 @@ Check:
 2. Supabase connection is working
 3. Job queue has pending jobs
 4. Runner has proper permissions
+
+If a runner crashes mid-job, stale `running` jobs are automatically re-queued
+once their heartbeat lease expires (`JOB_LEASE_TIMEOUT_SECONDS`).
 
 ### Converter errors
 

--- a/supabase/migrations/20260226000001_add_job_heartbeat_and_lease_recovery.sql
+++ b/supabase/migrations/20260226000001_add_job_heartbeat_and_lease_recovery.sql
@@ -1,0 +1,82 @@
+-- Migration: Add heartbeat support and lease-based stale job recovery
+-- Description:
+--   1) Track per-job runner heartbeat
+--   2) Requeue stale running jobs in claim_next_job before claiming a new job
+
+-- Track runner heartbeat for in-progress jobs
+ALTER TABLE jobs
+ADD COLUMN IF NOT EXISTS heartbeat_at TIMESTAMPTZ;
+
+-- Improve stale-running lookup performance
+CREATE INDEX IF NOT EXISTS idx_jobs_status_heartbeat_at ON jobs(status, heartbeat_at);
+CREATE INDEX IF NOT EXISTS idx_jobs_status_started_at ON jobs(status, started_at);
+
+-- Replace old one-arg function with lease-aware variant (second arg has default)
+DROP FUNCTION IF EXISTS claim_next_job(TEXT);
+
+CREATE OR REPLACE FUNCTION claim_next_job(
+  p_runner_id TEXT,
+  p_lease_timeout_seconds INTEGER DEFAULT 300
+)
+RETURNS SETOF jobs
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  claimed_job jobs%ROWTYPE;
+  lease_interval INTERVAL;
+BEGIN
+  -- Defensive lower bound to avoid accidental aggressive reclaim.
+  lease_interval := make_interval(secs => GREATEST(COALESCE(p_lease_timeout_seconds, 300), 30));
+
+  -- Requeue stale running jobs so they can be picked up again.
+  -- A job is stale if:
+  --   - heartbeat exists but is too old, or
+  --   - no heartbeat was ever recorded and started_at is too old.
+  UPDATE jobs
+  SET
+    status = 'queued',
+    started_at = NULL,
+    heartbeat_at = NULL,
+    updated_at = NOW(),
+    info = COALESCE(info, '{}'::jsonb) || jsonb_build_object(
+      'requeued_reason', 'lease_timeout',
+      'requeued_at', NOW()
+    )
+  WHERE status = 'running'
+    AND started_at IS NOT NULL
+    AND (
+      (heartbeat_at IS NOT NULL AND heartbeat_at < NOW() - lease_interval)
+      OR
+      (heartbeat_at IS NULL AND started_at < NOW() - lease_interval)
+    );
+
+  -- Select and lock the oldest queued job, skipping any locked rows.
+  SELECT * INTO claimed_job
+  FROM jobs
+  WHERE status = 'queued'
+  ORDER BY created_at ASC
+  LIMIT 1
+  FOR UPDATE SKIP LOCKED;
+
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  -- Mark as running and set initial heartbeat.
+  UPDATE jobs
+  SET
+    status = 'running',
+    started_at = NOW(),
+    heartbeat_at = NOW(),
+    updated_at = NOW(),
+    info = COALESCE(info, '{}'::jsonb) || jsonb_build_object('runner_id', p_runner_id)
+  WHERE id = claimed_job.id;
+
+  RETURN QUERY
+  SELECT * FROM jobs WHERE id = claimed_job.id;
+END;
+$$;
+
+COMMENT ON FUNCTION claim_next_job(TEXT, INTEGER)
+IS 'Atomically claim the next queued job and requeue stale running jobs using a lease timeout';


### PR DESCRIPTION
## Summary
- add job heartbeat tracking and lease-based stale-job recovery to the runner claim path
- add Supabase migration to store heartbeat_at and update claim_next_job to requeue stale running jobs
- update runner process to emit heartbeats while executing jobs and pass lease timeout to claim RPC
- add scheduled runner-watchdog GitHub Action to auto-restart production PM2 runner when offline
- document new heartbeat/lease environment settings

## Testing
- cd runner && npm ci
- cd runner && npm test
